### PR TITLE
🐛  Make the matcher not to fail on non-string text

### DIFF
--- a/lib/aho_corasick.rb
+++ b/lib/aho_corasick.rb
@@ -7,9 +7,9 @@ module Matchers
       @trie = Trie.new patterns
     end
 
-    def matches?(str)
+    def matches?(text)
       node = @trie.root
-      str.split('').each do |char|
+      text.to_s.split('').each do |char|
         node = node.failure while node.children[char].nil? # Follow failure if it exists in case pattern doesn't match
         node = node.children[char]
         return true unless node.output.nil?

--- a/lib/fluent/plugin/out_filter_list/version.rb
+++ b/lib/fluent/plugin/out_filter_list/version.rb
@@ -1,5 +1,5 @@
 module Fluent
   module OutFilterList
-    VERSION = "0.2.3"
+    VERSION = "0.2.4"
   end
 end

--- a/test/fluent/plugin/aho_corasick_test.rb
+++ b/test/fluent/plugin/aho_corasick_test.rb
@@ -87,9 +87,18 @@ class ACMatcherTest < Minitest::Test
     assert(!acmatcher.matches?('foo'))
   end
 
-  def test_blank_text_is_never_matched
-    kw = ['foo']
-    acmatcher = ACMatcher.new(kw)
-    assert(!acmatcher.matches?(''))
+  def test_nil_text_never_matches
+    matcher = ACMatcher.new(['xyz'])
+    assert !matcher.matches?(nil)
+  end
+
+  def test_blank_text_never_matches
+    matcher = ACMatcher.new(['foo'])
+    assert(!matcher.matches?(''))
+  end
+
+  def test_text_other_than_string_is_converted_to_string_before_comparison
+    acmatcher = ACMatcher.new(['999'])
+    assert acmatcher.matches?(999)
   end
 end


### PR DESCRIPTION
Make the plugin not to abort on a record of which value of filtered key is not a string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yanana/fluent-plugin-filter-list/1)
<!-- Reviewable:end -->
