### PR TITLE
🐛  Avoid invalid UTF-8 byte sequence error

### DIFF
--- a/lib/matcher.rb
+++ b/lib/matcher.rb
@@ -12,7 +12,7 @@ module Matchers
 
     def matches?(text)
       node = @trie.root
-      text.to_s.split('').each do |char|
+      text.to_s.chars.each do |char|
         node = node.failure while node.children[char].nil? # Follow failure if it exists in case pattern doesn't match
         node = node.children[char]
         return true unless node.output.nil?
@@ -50,7 +50,7 @@ module Matchers
 
     def insert(pattern = '')
       current_node = @root
-      pattern.split('').each_with_index do |char, i|
+      pattern.chars.each_with_index do |char, i|
         current_node = current_node.insert(char)
         current_node.output = pattern if i == pattern.length - 1
       end
@@ -83,7 +83,7 @@ module Matchers
     def forward_match(pattern)
       return false if @root.children.empty?
       cur_node = @root
-      pattern.split('').each do |char|
+      pattern.chars.each do |char|
         return true if cur_node.children.empty?
         return false unless cur_node.children.key?(char)
         cur_node = cur_node.children[char]

--- a/test/fluent/plugin/matcher_test.rb
+++ b/test/fluent/plugin/matcher_test.rb
@@ -51,6 +51,14 @@ class ACMatcherTest < Minitest::Test
     assert(!acmatcher.matches?('abcabc'))
   end
 
+  def test_not_matches_when_a_text_is_invalid_encoding
+    patterns = %w[foo bar]
+    matcher = ACMatcher.new(patterns)
+    # Create invalid UTF-8 byte sequence
+    text = "あ\244\255\192\193い".force_encoding('UTF-8')
+    assert(matcher.matches?(text) == false)
+  end
+
   def test_matches_when_a_pattern_is_at_the_head_of_text
     k1 = 'hoge'
     k2 = 'bar'


### PR DESCRIPTION
This PR partially resolves #20, by avoiding the _invalid UTF-8 byte sequence_ error using `String#chars` instead of `String#split`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yanana/fluent-plugin-filter-list/21)
<!-- Reviewable:end -->
